### PR TITLE
support selectors targeting two modifiers at the same time

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const SUFFIX = `(?:--${MODIFIER_NAME})?(?:\\.-${NO_NAMESPACE_MODIFIERS})?`;
 const PREFIX = `(?:\\.|(?=%))`; // component starts with a dot, placeholder needs a %
 
 const FILE_NAME = `^%?${BLOCK_NAME}$`
-const INITIAL_SELECTOR = `^(${PREFIX}{componentName}(?:__${ELEMENT_NAME})?)${SUFFIX}(\\1${SUFFIX})?$`;
+const INITIAL_SELECTOR = `^(${PREFIX}{componentName}(?:__${ELEMENT_NAME})?)${SUFFIX}((\\1|${ROOT_VARIABLE})${SUFFIX})?$`;
 const COMBINED_SELECTOR = `^(\\.{componentName}|${ROOT_VARIABLE})__${ELEMENT_NAME}${SUFFIX}$`;
 
 module.exports = {

--- a/tests/selector.test.js
+++ b/tests/selector.test.js
@@ -100,7 +100,32 @@ each([
   ['foo', '#foo', false],
   ['element', 'element', false],
 
-]).test('these selectors should match', (componentName, selector, shouldMatch) => {
+  // using #{$root} to allow combined modifiers
+  /**
+   * .foo {
+   *     $root: &
+   *     &--alpha {
+   *         &#{$root}--bravo {
+   *             // both modifiers at the same time
+   *         }
+   *     }
+   * }
+   */
+  ['foo', '.foo--alpha#{$root}--bravo', true],
+  /**
+   * .foo {
+   *     $root: &
+   *     &--alpha {
+   *         #{$root}--charlie#{$root}--bravo {
+   *             // the --charlie modifier has no business here
+   *         }
+   *     }
+   * }
+   */
+  ['foo', '#{$root}--charlie#{$root}--bravo', false],
+  ['foo', '#{$root}--other-mod.foo--mod', false],
+
+]).test('%s: "%s" selector should match: %p', (componentName, selector, shouldMatch) => {
 
   let warning = null;
 


### PR DESCRIPTION
# What’s happening here

We want to be able to create a selector targeting a node with _two modifiers at once_.

```html
<div class="foo foo--alpha">Ignored</div>
<div class="foo foo--bravo">Ignored</div>
<div class="foo foo--alpha foo--bravo">Matches</div>
```

```scss
// _foo.scss
.foo {
  $root: &
  &--alpha {
    &#{$root}--bravo {
       // look how fancy we are!
    }
  }
}
```

In order to do so, we basically allow appending modifiers to `$ROOT_VARIABLE`, not only to whatever was used in the leftmost part (referenced in scss by `&`, and in regex by `\\1`)